### PR TITLE
use staged build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,39 @@
 #
 # Unofficial Caddy 2 Docker image.
 #
+
+##### Build stage #####
 FROM golang:1.12-alpine
 
-# The index file indicates that the Caddy
-# container is up and running.
-COPY index.html /srv/index.html
+# Add git, clone the repository and switch to the
+RUN apk add git --no-cache
+RUN git clone https://github.com/caddyserver/caddy -b v2 caddy2
+
+WORKDIR caddy2/cmd/caddy
+
+RUN go build -v
+
+
+##### Final image stage #####
+
+FROM alpine:3.10
 
 # Create Caddy's working directory.
 RUN mkdir /caddy
 WORKDIR /caddy
 
-# Add git, clone the repository and switch to the
-# v2 branch since Caddy 2 is not in the master yet.
-RUN apk add git --no-cache
-RUN git clone https://github.com/caddyserver/caddy caddy2 \
-    && cd caddy2 \
-    && git fetch \
-    && git checkout v2
+# copy just built binary to new stage
+COPY --from=0 /go/caddy2/cmd/caddy/caddy /caddy/
 
-WORKDIR /caddy/caddy2/cmd/caddy
+# The index file indicates that the Caddy
+# container is up and running.
+COPY index.html /srv/index.html
 
 # The initial configuration declares a file server
 # delivering the index file in /srv.
 COPY initial-conf.json ./initial-conf.json
 
-RUN go build -v
-CMD ["./caddy", "run", "--config", "initial-conf.json"]
+CMD ["/caddy/caddy", "run", "--config", "initial-conf.json"]
 
 EXPOSE 2019
 EXPOSE 2080


### PR DESCRIPTION
This PR adds a extra stage for compiling. This prevents build tools (git, go) ending up in the final image.